### PR TITLE
Handle Recipe Radar's minimap tracking radar

### DIFF
--- a/ElvUI_MinimapButtons/ElvUI_MinimapButtons.lua
+++ b/ElvUI_MinimapButtons/ElvUI_MinimapButtons.lua
@@ -242,6 +242,8 @@ local GenericIgnores = {
 	"LibRockConfig-1.0_MinimapButton",
 	-- Nauticus
 	"Naut_MiniMapIconButton",
+	-- Recipe Radar
+	"RecipeRadarMinimapIcon", -- NPC tracking icons, all suffixed from 1 to 20.
 }
 
 local PartialIgnores = {

--- a/ElvUI_MinimapButtons/ElvUI_MinimapButtons.toc
+++ b/ElvUI_MinimapButtons/ElvUI_MinimapButtons.toc
@@ -1,7 +1,7 @@
 ﻿## Interface: 20400
 ## Title: |cff00b30bE|r|cffC4C4C4lvUI|r |cff00b30bM|r|cffC4C4C4inimap|r |cff00b30bB|r|cffC4C4C4uttons|r
 ## Author: Pinya, Bunny
-## Version: 1.02
+## Version: 1.03
 ## RequiredDeps: ElvUI
 ## OptionalDeps: Atlas, DBM-Core, Enchantrix, RecipeRadar
 


### PR DESCRIPTION
This adds support for the minimap tracking radar icons... a Recipe Radar feature that I didn't notice in my first contribution (#4).

Edit: The reason this fix was necessary is because if you track vendors in Recipe Radar, it adds minimap icons like a "radar", which ElvUI was collecting (wrongly)...